### PR TITLE
Add 'skipMultiColor' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,7 @@ function gradientToFilter(gradient) {
 
     return {
         string: filterGradient(startColor, endColor, type),
+        isMultiColor: obj.colorStops.length > 2,
         isFallback: result.isFallback,
         message: result.message
     };
@@ -182,6 +183,8 @@ module.exports = postcss.plugin('postcss-filter-gradient', function (opts) {
     opts = opts || {};
     opts.angleFallback =
         opts.angleFallback === undefined ?  true : opts.angleFallback;
+    opts.skipMultiColor =
+        opts.skipMultiColor === undefined ? false : opts.skipMultiColor;
 
     return function (root, result) {
         root.walkRules(function (rule) {
@@ -197,6 +200,10 @@ module.exports = postcss.plugin('postcss-filter-gradient', function (opts) {
 
                 if (gradient.value) {
                     filter = gradientToFilter(gradient.value);
+
+                    if (opts.skipMultiColor && filter.isMultiColor) {
+                        return;
+                    }
 
                     if (!opts.angleFallback && filter.isFallback) {
                         return;


### PR DESCRIPTION
Since the IE filter does not support gradients with three or more colors, there should be an option to skip filter gradient generation for those rules (useful when you instead want a _background_ color fallback)
