### PR TITLE
Add support for direction without "to"

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,26 @@ function parseGradient(str) {
     // match side and any corner, in browser,
     // `top right` and `right top` are the same,
     // so we should put this situation into consideration
-    /* eslint-disable max-len */
-    var rSideCorner = /to\s+((?:left|right|top|bottom)|(?:(?:(?:left|right)\s+(?:top|bottom))|(?:(?:top|bottom)\s+(?:left|right))))(?=\s*,)/;
+    var rSideCorner = new RegExp(
+      'to\\s+' +
+      '(' + // 1
+          '(?:left|right|top|bottom)' +
+          '|' +
+          '(?:' +
+              '(?:' + // left top, left bottom, right top, right bottom
+                  '(?:left|right)\\s+(?:top|bottom)' +
+              ')' +
+              '|' +
+              '(?:' + // top left, top right, bottom left, bottom right
+                  '(?:top|bottom)\\s+(?:left|right)' +
+              ')' +
+          ')' +
+      ')' + // end 1
+      '(?=\\s*,)'
+    );
+
     // match color stops, the color format is not very precise
+    /* eslint-disable max-len */
     var rColorStops = /\s*(#[0-9a-f]{3,6}|(?:hsl|rgb)a?\(.+?\)|\w+)(?:\s+((?:[+-]?\d*\.?\d+)(?:%|[a-z]+)?))?/gi;
     // the final gradient line regexp
     var rGradientLine = new RegExp('^\\s*' + rAngle.source + '|' + rSideCorner.source, 'i');

--- a/test/fixtures/bottom.css
+++ b/test/fixtures/bottom.css
@@ -1,0 +1,3 @@
+a {
+    background: linear-gradient(bottom, #1E5799, #7DB9E8);
+}

--- a/test/fixtures/bottom.expect.css
+++ b/test/fixtures/bottom.expect.css
@@ -1,0 +1,4 @@
+a {
+    background: linear-gradient(bottom, #1E5799, #7DB9E8);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff7db9e8', endColorstr='#ff1e5799', GradientType=0);
+}

--- a/test/fixtures/left.css
+++ b/test/fixtures/left.css
@@ -1,0 +1,3 @@
+a {
+    background: linear-gradient(left, #1E5799, #7DB9E8);
+}

--- a/test/fixtures/left.expect.css
+++ b/test/fixtures/left.expect.css
@@ -1,0 +1,4 @@
+a {
+    background: linear-gradient(left, #1E5799, #7DB9E8);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff1e5799', endColorstr='#ff7db9e8', GradientType=1);
+}

--- a/test/fixtures/right.css
+++ b/test/fixtures/right.css
@@ -1,0 +1,3 @@
+a {
+    background: linear-gradient(right, #1E5799, #7DB9E8);
+}

--- a/test/fixtures/right.expect.css
+++ b/test/fixtures/right.expect.css
@@ -1,0 +1,4 @@
+a {
+    background: linear-gradient(right, #1E5799, #7DB9E8);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff7db9e8', endColorstr='#ff1e5799', GradientType=1);
+}

--- a/test/fixtures/top.css
+++ b/test/fixtures/top.css
@@ -1,0 +1,3 @@
+a {
+    background: linear-gradient(top, #1E5799, #7DB9E8);
+}

--- a/test/fixtures/top.expect.css
+++ b/test/fixtures/top.expect.css
@@ -1,0 +1,4 @@
+a {
+    background: linear-gradient(top, #1E5799, #7DB9E8);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff1e5799', endColorstr='#ff7db9e8', GradientType=0);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -50,8 +50,24 @@ describe('postcss-filter-gradient', function () {
         test('simple', {}, done);
     });
 
+    it('should support top', function (done) {
+        test('top', {}, done);
+    });
+
+    it('should support bottom', function (done) {
+        test('bottom', {}, done);
+    });
+
     it('should support vertical reverse', function (done) {
         test('vertical-reverse', {}, done);
+    });
+
+    it('should support right', function (done) {
+        test('right', {}, done);
+    });
+
+    it('should support left', function (done) {
+        test('left', {}, done);
     });
 
     it('should support horizontal direction', function (done) {


### PR DESCRIPTION
I tried running this plugin on a codebase with some old, vendored code
in it, and ran into an error when trying to parse a style like the
following:

``` css
background: linear-gradient(top, #f00, #00f);
```

To fix this and generate the expected gradients, I needed to modify the
side corner regex to take the presence or absence of "to" into account
and then modify the direction if it was not there.
