### PR TITLE
New option to skip warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ module.exports = postcss.plugin('postcss-filter-gradient', function (opts) {
     opts.skipMultiColor =
         opts.skipMultiColor === undefined ? false : opts.skipMultiColor;
     opts.skipWarnings =
-        opts.skipWarnings === undefined ? true : opts.skipWarnings;
+        opts.skipWarnings === undefined ? false : opts.skipWarnings;
 
     return function (root, result) {
         root.walkRules(function (rule) {

--- a/index.js
+++ b/index.js
@@ -253,6 +253,8 @@ module.exports = postcss.plugin('postcss-filter-gradient', function (opts) {
         opts.angleFallback === undefined ?  true : opts.angleFallback;
     opts.skipMultiColor =
         opts.skipMultiColor === undefined ? false : opts.skipMultiColor;
+    opts.skipWarnings =
+        opts.skipWarnings === undefined ? true : opts.skipWarnings;
 
     return function (root, result) {
         root.walkRules(function (rule) {
@@ -261,14 +263,17 @@ module.exports = postcss.plugin('postcss-filter-gradient', function (opts) {
 
             gradient = getGradientFromRule(rule);
 
-            // if linear-gradient and `filter` both exist, warn users
-            if (gradient.value && hasFilter(rule)) {
-                rule.warn(
-                    result,
-                    'The `filter` declaration already exists, we have skipped this rule.'
-                );
-                return;
+            if (opts.skipWarnings === false) {
+              // if linear-gradient and `filter` both exist, warn users
+              if (gradient.value && hasFilter(rule)) {
+                  rule.warn(
+                      result,
+                      'The `filter` declaration already exists, we have skipped this rule.'
+                  );
+                  return;
+              }
             }
+
 
             if (gradient.warnings) {
                 gradient.decl.warn(result, gradient.warnings);


### PR DESCRIPTION
`filtergradient({skipWarnings: true})` will now ignore the warning if filter exists. We needed to keep existing filter in some cases for our project and the warnings were not useful in the terminal when running build script.